### PR TITLE
Update LICENSE/NOTICE to match Daffodil

### DIFF
--- a/nifi-daffodil-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-daffodil-nar/src/main/resources/META-INF/LICENSE
@@ -207,82 +207,8 @@ The NIFI DAFFODIL NAR project contains subcomponents with separate
 copyright notices and license terms. Your use of the source code for the these
 subcomponents is subject to the terms and conditions of the following licenses.
 
-  This product bundles compiled source from 'Passera', including the following
-  files:
-    - passera/ directory in daffodil-lib-<VERSION>.jar
-  These files are available under the BSD-2-Clause license:
-
-    Copyright (c) 2011-2013, Nate Nystrom
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    Redistributions of source code must retain the above copyright notice, this
-    list of conditions and the following disclaimer.
-
-    Redistributions in binary form must reproduce the above copyright notice, this
-    list of conditions and the following disclaimer in the documentation and/or
-    other materials provided with the distribution.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-  This product bundles material copied or derived from W3C, including the
-  following files:
-    - org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd) in daffodil-lib-<VERSION>.jar
-    - org/apache/daffodil/xsd/XMLSchema.xsd (https://www.w3.org/2001/XMLSchema.xsd) in daffodil-lib-<VERSION>.jar
-    - org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd (https://www.w3.org/2001/XMLSchema.dtd) in daffodil-lib-<VERSION>.jar
-    - org/apache/daffodil/xsd/datatypes.dtd (https://www.w3.org/2001/datatypes.dtd) in daffodil-lib-<VERSION>.jar
-    - org/apache/daffodil/xsd/xml.xsd (https://www.w3.org/2001/xml.xsd) in daffodil-lib-<VERSION>.jar
-  These files are available under the W3C Software and Document Licnese:
-
-    By obtaining and/or copying this work, you (the licensee) agree that you have
-    read, understood, and will comply with the following terms and conditions.
-
-    Permission to copy, modify, and distribute this work, with or without
-    modification, for any purpose and without fee or royalty is hereby granted,
-    provided that you include the following on ALL copies of the work or portions
-    thereof, including modifications:
-
-    * The full text of this NOTICE in a location viewable to users of the
-      redistributed or derivative work.
-
-    * Any pre-existing intellectual property disclaimers, notices, or terms and
-      conditions. If none exist, the W3C Software and Document Short Notice should be
-      included.
-
-    * Notice of any changes or modifications, through a copyright statement on the
-      new code or document such as "This software or document includes material
-      copied from or derived from [title and URI of the W3C document]. Copyright ©
-      [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
-
-    Disclaimers
-
-    THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO
-    REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
-    LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR
-    PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY
-    THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-
-    COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
-    CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
-
-    The name and trademarks of copyright holders may NOT be used in advertising
-    or publicity pertaining to the work without specific, written prior
-    permission. Title to copyright in this work will at all times remain with
-    copyright holders.
-
   This product bundles 'ICU4J', including the following files:
-    - icu4j-<VERSION>.jar
+    - META-INF/bundled-dependencies/icu4j-<VERSION>.jar
   These files are available under the Unicode License. For details, see
   https://github.com/unicode-org/icu/blob/release-<VERSION>/icu4c/LICENSE
 
@@ -573,8 +499,8 @@ subcomponents is subject to the terms and conditions of the following licenses.
      #  and others. All Rights Reserved.
      #
      # Project: https://github.com/veer66/lao-dictionary
-     # Dictionary: https://github.com/veer66/lao-dictionary/blob/master/Lao-Dictionary.txt
-     # License: https://github.com/veer66/lao-dictionary/blob/master/Lao-Dictionary-LICENSE.txt
+     # Dictionary: https://github.com/veer66/lao-dictionary/blob/2c2344310636f548b09d854362ab2e2e666369e0/Lao-Dictionary.txt
+     # License: https://github.com/veer66/lao-dictionary/blob/2c2344310636f548b09d854362ab2e2e666369e0/Lao-Dictionary-LICENSE.txt
      #              (copied below)
      #
      #  This file is derived from the above dictionary, with slight
@@ -702,7 +628,7 @@ subcomponents is subject to the terms and conditions of the following licenses.
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   This product bundles 'JDOM2', including the following files:
-    - jdom2-<VERSION>.jar
+    - META-INF/bundled-dependencies/jdom2-<VERSION>.jar
   These files are available under an Apache style License:
 
     Redistribution and use in source and binary forms, with or without
@@ -754,8 +680,36 @@ subcomponents is subject to the terms and conditions of the following licenses.
     Brett McLaughlin <brett_AT_jdom_DOT_org>.  For more information
     on the JDOM Project, please see <http://www.jdom.org/>. 
 
+  This product bundles 'Passera' compiled source, including the following files:
+    - passera/ directory in META-INF/bundled-dependencies/daffodil-lib-<VERSION>.jar
+  These files are available under the BSD-2-Clause license:
+
+    Copyright (c) 2011-2013, Nate Nystrom
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice, this
+    list of conditions and the following disclaimer in the documentation and/or
+    other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
   This product bundles 'Stax 2 API', including the following files:
-    - stax2-api-<VERSION>.jar
+    - META-INF/bundled-dependencies/stax2-api-<VERSION>.jar
   These files are available under the BSD-2-Clause license:
 
     Copyright 2010- FasterXML.com
@@ -781,9 +735,53 @@ subcomponents is subject to the terms and conditions of the following licenses.
     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  This product bundles libraries from 'os-lib', including the following files:
-    - geny_<VERSION>.jar
-    - os-lib_<VERSION>.jar
+  This product bundles 'W3C' copied or derived material, including the following files:
+    - org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd) in META-INF/bundled-dependencies/daffodil-lib-<VERSION>.jar
+    - org/apache/daffodil/xsd/XMLSchema.xsd (https://www.w3.org/2001/XMLSchema.xsd) in META-INF/bundled-dependencies/daffodil-lib-<VERSION>.jar
+    - org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd (https://www.w3.org/2001/XMLSchema.dtd) in META-INF/bundled-dependencies/daffodil-lib-<VERSION>.jar
+    - org/apache/daffodil/xsd/datatypes.dtd (https://www.w3.org/2001/datatypes.dtd) in META-INF/bundled-dependencies/daffodil-lib-<VERSION>.jar
+    - org/apache/daffodil/xsd/xml.xsd (https://www.w3.org/2001/xml.xsd) in META-INF/bundled-dependencies/daffodil-lib-<VERSION>.jar
+  These files are available under the W3C Software and Document License:
+
+    By obtaining and/or copying this work, you (the licensee) agree that you have
+    read, understood, and will comply with the following terms and conditions.
+
+    Permission to copy, modify, and distribute this work, with or without
+    modification, for any purpose and without fee or royalty is hereby granted,
+    provided that you include the following on ALL copies of the work or portions
+    thereof, including modifications:
+
+    * The full text of this NOTICE in a location viewable to users of the
+      redistributed or derivative work.
+
+    * Any pre-existing intellectual property disclaimers, notices, or terms and
+      conditions. If none exist, the W3C Software and Document Short Notice should be
+      included.
+
+    * Notice of any changes or modifications, through a copyright statement on the
+      new code or document such as "This software or document includes material
+      copied from or derived from [title and URI of the W3C document]. Copyright ©
+      [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
+
+    Disclaimers
+
+    THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO
+    REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+    LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR
+    PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY
+    THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+    COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+    CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+    The name and trademarks of copyright holders may NOT be used in advertising
+    or publicity pertaining to the work without specific, written prior
+    permission. Title to copyright in this work will at all times remain with
+    copyright holders.
+
+  This product bundles 'os-lib', including the following files:
+    - META-INF/bundled-dependencies/geny_<VERSION>.jar
+    - META-INF/bundled-dependencies/os-lib_<VERSION>.jar
   These files are available under the MIT license:
 
     License

--- a/nifi-daffodil-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-daffodil-nar/src/main/resources/META-INF/NOTICE
@@ -3,7 +3,7 @@ Copyright 2021 Owl Cyber Defense
 
 The following NOTICE information applies to binary components distributed with this project:
 
-Apache Daffodil (daffodil-<VERSION>.jar)
+Apache Daffodil (META-INF/bundled-dependencies/daffodil-<VERSION>.jar)
   Apache Daffodil
   Copyright 2021 The Apache Software Foundation
 
@@ -15,20 +15,49 @@ Apache Daffodil (daffodil-<VERSION>.jar)
   - Tresys Technology (http://www.tresys.com/)
   - International Business Machines Corporation (http://www.ibm.com)
 
-Apache Commons IO (commons-io-<VERSION>.jar)
+Apache Commons IO (META-INF/bundled-dependencies/commons-io-<VERSION>.jar)
   Apache Commons IO
-  Copyright 2002-2020 The Apache Software Foundation
+  Copyright 2002-2021 The Apache Software Foundation
 
   This product includes software developed at
   The Apache Software Foundation (https://www.apache.org/).
 
-Apache NiFi Utils (nifi-utils-<VERSION>.jar)
+Apache Log4j (META-INF/bundled-dependencies/log4j-api-<VERSION>.jar)
+  Apache Log4j
+  Copyright 1999-2019 Apache Software Foundation
+
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
+
+  ResolverUtil.java
+  Copyright 2005-2006 Tim Fennell
+
+  Dumbster SMTP test server
+  Copyright 2004 Jason Paul Kitchen
+
+  TypeUtil.java
+  Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+  picocli (http://picocli.info)
+  Copyright 2017 Remko Popma
+
+Apache Log4j Scala API (META-INF/bundled-dependencies/log4j-api-scala_<VERSION>.jar)
+  Copyright 2016-2018 Apache Software Foundation
+
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
+
+  AsciidocPlugin.scala
+  Copyright (c) 2008, 2009, 2010, 2011 Josh Suereth, Steven Blundy, Josh Cough,
+  Mark Harrah, Stuart Roebuck, Tony Sloane, Vesa Vilhonen, Jason Zaugg
+
+Apache NiFi Utils (META-INF/bundled-dependencies/nifi-utils-<VERSION>.jar)
   nifi-utils
   Copyright 2017 Apache NiFi Project
 
-Apache Xerces Java (xercesImpl-<VERSION>.jar)
+Apache Xerces Java (META-INF/bundled-dependencies/xercesImpl-<VERSION>.jar)
   Apache Xerces Java
-  Copyright 1999-2020 The Apache Software Foundation
+  Copyright 1999-2022 The Apache Software Foundation
 
   This product includes software developed at
   The Apache Software Foundation (http://www.apache.org/).
@@ -40,34 +69,34 @@ Apache Xerces Java (xercesImpl-<VERSION>.jar)
       Apache Software Foundation that were originally developed at iClick, Inc.,
       software copyright (c) 1999.
 
-Apache XML Commons Resolver (xml-resolver-<VERSION>.jar)
-    Apache XML Commons Resolver
-    Copyright 2006 The Apache Software Foundation.
+Apache XML Commons Resolver (META-INF/bundled-dependencies/xml-resolver-<VERSION>.jar)
+  Apache XML Commons Resolver
+  Copyright 2006 The Apache Software Foundation.
 
-    This product includes software developed at
-    The Apache Software Foundation http://www.apache.org/
+  This product includes software developed at
+  The Apache Software Foundation http://www.apache.org/
 
-    Portions of this code are derived from classes placed in the
-    public domain by Arbortext on 10 Apr 2000. See:
-    http://www.arbortext.com/customer_support/updates_and_technical_notes/catalogs/docs/README.htm
+  Portions of this code are derived from classes placed in the
+  public domain by Arbortext on 10 Apr 2000. See:
+  http://www.arbortext.com/customer_support/updates_and_technical_notes/catalogs/docs/README.htm
 
-Apache XML Commons XML APIs (xml-apis-<VERSION>.jar)
-   Apache XML Commons XML APIs
-   Copyright 1999-2009 The Apache Software Foundation.
+Apache XML Commons XML APIs (META-INF/bundled-dependencies/xml-apis-<VERSION>.jar)
+  Apache XML Commons XML APIs
+  Copyright 1999-2009 The Apache Software Foundation.
 
-   This product includes software developed at
-   The Apache Software Foundation (http://www.apache.org/).
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
 
-   Portions of this software were originally based on the following:
-     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-     - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
+  Portions of this software were originally based on the following:
+    - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+    - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+    - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
 
-Guava (guava-<VERSION>.jar)
+Guava (META-INF/bundled-dependencies/guava-<VERSION>.jar)
   Guava
   Copyright 2015 The Guava Authors
 
-JDOM2 (jdom2-<VERSION>.jar)
+JDOM2 (META-INF/bundled-dependencies/jdom2-<VERSION>.jar)
   Copyright (C) 2000-2012 Jason Hunter & Brett McLaughlin.
 
   All rights reserved.
@@ -75,7 +104,7 @@ JDOM2 (jdom2-<VERSION>.jar)
   This product includes software developed by the
   JDOM Project (http://www.jdom.org/).
 
-Jackson JSON processor (jackson-core-<VERSION>.jar)
+Jackson JSON processor (META-INF/bundled-dependencies/jackson-core-<VERSION>.jar)
   Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
   Copyright (c) 2008-2020 FasterXML. All rights reserved.
 
@@ -97,8 +126,8 @@ Jackson JSON processor (jackson-core-<VERSION>.jar)
   in some artifacts (usually source distributions); but is always available
   from the source code management (SCM) system project uses.
 
-Scala (scala-library-<VERSION>.jar)
-      (org/apache/daffodil/util/UniquenessCache.class in daffodil-lib-<VERSION>.jar)
+Scala (META-INF/bundled-dependencies/scala-library-<VERSION>.jar)
+      (org/apache/daffodil/util/UniquenessCache.class in META-INF/bundled-dependencies/daffodil-lib-<VERSION>.jar)
   Scala
   Copyright (c) 2002-2020 EPFL
   Copyright (c) 2011-2020 Lightbend, Inc.
@@ -112,7 +141,7 @@ Scala (scala-library-<VERSION>.jar)
   and can be found in:
     daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
 
-Scala Parser Combinators (scala-parser-combinators_<VERSION>.jar)
+Scala Parser Combinators (META-INF/bundled-dependencies/scala-parser-combinators_<VERSION>.jar)
   Scala parser combinators
   Copyright (c) 2002-2021 EPFL
   Copyright (c) 2011-2021 Lightbend, Inc.
@@ -121,7 +150,7 @@ Scala Parser Combinators (scala-parser-combinators_<VERSION>.jar)
   LAMP/EPFL (https://lamp.epfl.ch/) and
   Lightbend, Inc. (https://www.lightbend.com/).
 
-Scala XML (scala-xml_<VERSION>.jar)
+Scala XML (META-INF/bundled-dependencies/scala-xml_<VERSION>.jar)
   scala-xml
   Copyright (c) 2002-2020 EPFL
   Copyright (c) 2011-2020 Lightbend, Inc.


### PR DESCRIPTION
Includes minor additions for dependencies specific to this processor
(e.g. Guava, NiFi Utils)