### PR TITLE
Add support for setting DFDL external variables

### DIFF
--- a/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/DaffodilCompileException.java
+++ b/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/DaffodilCompileException.java
@@ -18,7 +18,7 @@ package com.owlcyberdefense.nifi.processors;
 
 import java.io.IOException;
 
-public class DaffodilCompileException extends IOException {
+public class DaffodilCompileException extends Exception {
 
     public DaffodilCompileException() {
         super();

--- a/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/DaffodilParse.java
+++ b/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/DaffodilParse.java
@@ -25,6 +25,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 
 import org.apache.nifi.annotation.behavior.EventDriven;
+import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
@@ -32,6 +33,7 @@ import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
 
@@ -51,6 +53,12 @@ import org.apache.daffodil.japi.infoset.XMLTextInfosetOutputter;
 @Tags({"xml", "json", "daffodil", "dfdl", "schema", "xsd"})
 @CapabilityDescription("Use Daffodil and a user-specified DFDL schema to transform data to an infoset, represented by either XML or JSON.")
 @WritesAttribute(attribute = "mime.type", description = "Sets the mime type to application/json or application/xml based on the infoset type.")
+@DynamicProperty(
+    name = "Name of external variable defined in a DFDL schema",
+    value = "Value to set for the DFDL external variable. May be an expression. The DFDL variable is not set if the value expression evaluates to an empty string.",
+    description = "Defines an external variable to be used when parsing",
+    expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES
+)
 @RequiresInstanceClassLoading
 public class DaffodilParse extends AbstractDaffodilProcessor {
 

--- a/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/DaffodilUnparse.java
+++ b/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/DaffodilUnparse.java
@@ -25,6 +25,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 
 import org.apache.nifi.annotation.behavior.EventDriven;
+import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
@@ -32,6 +33,7 @@ import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
 
@@ -48,6 +50,12 @@ import org.apache.daffodil.japi.infoset.XMLTextInfosetInputter;
 @Tags({"xml", "json", "daffodil", "dfdl", "schema", "xsd"})
 @CapabilityDescription("Use Daffodil and a user-specified DFDL schema to transform an XML or JSON representation of data back to the original data format.")
 @WritesAttribute(attribute = "mime.type", description = "If the FlowFile is successfully unparsed, this attriute is removed, as the MIME Type is no longer known.")
+@DynamicProperty(
+    name = "Name of external variable defined in a DFDL schema",
+    value = "Value to set for the DFDL external variable. May be an expression. The DFDL variable is not set if the value expression evaluates to an empty string.",
+    description = "Defines an external variable to be used when parsing",
+    expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES
+)
 @RequiresInstanceClassLoading
 public class DaffodilUnparse extends AbstractDaffodilProcessor {
 

--- a/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilParse/additionalDetails.html
+++ b/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilParse/additionalDetails.html
@@ -19,7 +19,7 @@
 <head>
     <meta charset="utf-8" />
     <title>DaffodilParse</title>
-    <link rel="stylesheet" href="../../css/component-usage.css" type="text/css" />
+    <link rel="stylesheet" href="/nifi-docs/css/component-usage.css" type="text/css" />
 </head>
 
 <body>
@@ -46,80 +46,107 @@
 <p>
     Publicly available DFDL schemas are available on the <a href="https://github.com/DFDLSchemas">DFDL Schemas github</a>.
 </p>
+<h2>External Variables</h2>
+<p>
+    DFDL external variables are supported using NiFi's dynamic properties.
+</p>
+<p>
+    To set an external variable, click the <code>"+"</code> sign in the top right of the processor's
+    properties tab to add a new dynamic property. The name of the property should be the same as the name of the
+    variable. Additionally, if the variable name alone is ambiguous, you can provide a namespace prefix and a
+    colon (e.g. <code>ns:variableName</code>) or a full namespace URI surrounded by curly braces (e.g.
+    <code>{http://example.com/namespace}variableName</code>).
+</p>
+<p>
+    The value of the dynamic property is used for the value of the variable, and can be a simple value or a NiFi
+    expression to be evaluated for each flow file. In either case, if the value is the empty string, the variable is
+    ignored for that flowfile and is not provided to Daffodil. This is useful in cases where a NiFi expression
+    determines a variable is not valid for the 'DFDL Schema File' being used, or to temporarily disable a variable
+    without completely removing it.
+</p>
+
 <h2>Plugins and Schemas</h2>
 <p>
-    <p>
     The <tt>Plugins and Schemas</tt> property is a comma separated list of paths to files and/or directories that the
     processor can use to find Daffodil plugins and schemas.
-    </p>
-    <dl>
-        <dt>Plugins</dt>
-        <dd>
-            <p>
-            Some DFDL schemas may require the use of plugins, such as layers, user defined functions, or custom
-            character encodings. To make these available to NiFi Daffodil processors, these plugins can be compiled to
-            jars, and paths to the jars or parent directory may be added to the <tt>Plugins and Schemas</tt> property. For
-            example, if all Daffodil plugins are in the <tt>/usr/share/nifi-daffodil/plugins/</tt> directory, you might
-            set the property to the following:
-            </p>
-
-            <pre>
-            Plugins and Schemas: /usr/share/nifi-daffodil/plugins/</pre>
-        </dd>
-        <dt>Schemas</dt>
-        <dd>
-            <p>
-            The <tt>DFDL Schema File</tt> property is used to define the path to a schema to be compiled, or a saved
-            parser to reload if <tt>Pre-compiled schema</tt> is true. However, in some cases it may be more convenient
-            to provide the schema as a path inside a jar, or as just a filename instead of a full path. The <tt>Plugins
-            and Schemas</tt> property can be used for this purpose.
-            </p>
-
-            <p>
-            If a schema (or saved parser) is defined in a jar, then add the jar to the <tt>Plugins and Schemas</tt>
-            property (either as a path to the directory containing the jar or a path to the jar itself), and set the
-            <tt>DFDL Schema File</tt> property to the <i>absolute path</i> to the schema <i>inside</i> the jar. For
-            example, if a jar at <tt>/usr/share/nifi-daffodil/schemas/dfdl-foo.jar</tt> contains a DFDL schema file
-            called <tt>com/example/foo.dfdl.xsd</tt>, you might configure the following:
-            </p>
-
-            <pre>
-            DFDL Schema File: /com/example/foo.dfdl.xsd
-            Plugins and Schemas: /usr/share/nifi-daffodil/schemas/</pre>
-
-            <p>
-            If a schema (or saved parser) is not in a jar, then add the file to the <tt>Plugins and Schemas</tt>
-            property (either as a path to the directory containing the file or a path to the file itself) and set the
-            <tt>DFDL Schema File</tt> property to just the file name. For example, if a saved parser is at
-            <tt>/usr/share/nifi-daffodil/saved-parsers/foo.bin</tt>, you might configure the following:
-            </p>
-
-            <pre>
-            DFDL Schema File: foo.bin
-            Plugins and Schemas: /usr/share/nifi-daffodil/saved-parsers/
-            Pre-compiled Schema: true</pre>
-        </dd>
-    </dl>
 </p>
+
+<h3>Plugins</h3>
+<p>
+    Some DFDL schemas may require the use of plugins, such as layers, user defined functions, or custom character
+    encodings. To make these available to NiFi Daffodil processors, these plugins can be compiled to jars, and paths to
+    individual jars or to a parent directory containing one or more jars may be added to the <tt>Plugins and
+    Schemas</tt> property. For example, if all Daffodil plugins are in the <tt>/usr/share/nifi-daffodil/plugins/</tt>
+    directory, you might set the property to the following:
+</p>
+<code><pre>
+Plugins and Schemas: /usr/share/nifi-daffodil/plugins/
+</pre></code>
+
+<h3>Schemas</h3>
+<p>
+    The <tt>DFDL Schema File</tt> property is used to define the path to a schema to be compiled, or a saved
+    parser to reload if <tt>Pre-compiled schema</tt> is true. However, in some cases it may be more convenient
+    to provide the schema as a path inside a jar, or as just a filename instead of a full path. The <tt>Plugins
+    and Schemas</tt> property can be used for this purpose.
+</p>
+<p>
+    If a schema (or saved parser) is defined in a jar, then add the jar to the <tt>Plugins and Schemas</tt>
+    property (either as a path to the directory containing the jar or a path to the jar itself), and set the
+    <tt>DFDL Schema File</tt> property to the <i>absolute path</i> to the schema <i>inside</i> the jar. For
+    example, if a jar at <tt>/usr/share/nifi-daffodil/schemas/dfdl-foo.jar</tt> contains a DFDL schema file
+    called <tt>com/example/foo.dfdl.xsd</tt>, you might configure the following:
+</p>
+<code><pre>
+DFDL Schema File: /com/example/foo.dfdl.xsd
+Plugins and Schemas: /usr/share/nifi-daffodil/schemas/
+</pre></code>
+<p>
+    In the above example, notice how the DFDL Schema File path begins with a '/', which denotes that the file is to be
+    found at that location inside a jar file.
+</p>
+<p>
+    If a schema (or saved parser) is not in a jar, then add the file to the <tt>Plugins and Schemas</tt>
+    property (either as a path to the directory containing the file or a path to the file itself) and set the
+    <tt>DFDL Schema File</tt> property to just the file name. For example, if a saved parser is at
+    <tt>/usr/share/nifi-daffodil/saved-parsers/foo.bin</tt>, you might configure the following:
+</p>
+<code><pre>
+DFDL Schema File: foo.bin
+Plugins and Schemas: /usr/share/nifi-daffodil/saved-parsers/
+Pre-compiled Schema: true
+</pre></code>
+
 <h2>Compiled DFDL Schema Cache</h2>
 <p>
     Before a FlowFile can be parsed or unparsed, Daffodil first compiles the DFDL schema to an internal data
-    structure. This compilation can be relatively slow, so once a schema is compiled it is cached inside this
+    structure. This compilation can be relatively slow, so once a schema is compiled, it is cached inside this
     NiFi processor for rapid reuse. The following properties are provided to control how this cache is
     maintained:
     <dl>
         <dt>Cache Size</dt>
         <dd>
+            <p>
             Defines the maximum number of DFDL schemas that can be compiled and saved for rapid reuse from the
             cache. To avoid compilation, it is recommended that this value be larger than the expected number
             of possible DFDL schemas. Setting this value to 0 disables the cache, though this is not
-            recommended.
+            recommended. The default value is 50.
+            </p>
         </dd>
         <dt>Cache TTL after last access</dt>
         <dd>
-            Defines the cache time-to-live, or how long to keep an unused compiled DFDL schemas in the cache. To avoid
-            compilation, it is recommended that this should be larger than the amount of time it is expected
-            for a DFDL schema to be unused.
+            <p>
+            Cached compiled DFDL schemas that go unused for a specified amount of time are removed from the cache to
+            save memory. This time is defind by the <tt>Cache TTL after last access</tt> property, with the format of
+            <tt>&lt;duration&gt; &lt;time_unit&gt;</tt>, where <tt>&lt;duration&gt;</tt> is a non-negative integer and
+            <tt>&lt;time_unit&gt;</tt> is a supported unit of time, such as nanos, millis, secs, mins, hrs, days. If set
+            to zero (e.g. "0 seconds"), cached compiled DFDL schemas are never removed from the cache. The default value
+            is 30 minutes.
+            </p>
+            <p>
+            For example, if a schema is used occasionally (once a day perhaps), then set this to <tt>24 hours</tt> to
+            avoid recompiling it each time it is used.
+            </p>
         </dd>
     </dl>
 </p>

--- a/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilUnparse/additionalDetails.html
+++ b/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilUnparse/additionalDetails.html
@@ -19,7 +19,7 @@
 <head>
     <meta charset="utf-8" />
     <title>DaffodilUnparse</title>
-    <link rel="stylesheet" href="../../css/component-usage.css" type="text/css" />
+    <link rel="stylesheet" href="/nifi-docs/css/component-usage.css" type="text/css" />
 </head>
 
 <body>
@@ -39,7 +39,7 @@
     is a language capable of describing many data formats, including textual and binary, commercial
     record-oriented, scientific and numeric, modern and legacy, and many industry standards. It leverages XML
     technology and concepts, using a subset of W3C XML schema type system and annotations to describe such
-    data. Daffodil uses this data description to "parse" data into an XML representation of the data. This
+    data. Daffodil uses this data description to "parse" data into an XML or JSON representation of the data. This
     allows one to take advantage of the many XML and JSON technologies (e.g. XQuery, XPath, XSLT) to ingest, validate,
     and manipulate complex data formats. Daffodil can also use this data description to "unparse", or
     serialize, the XML or JSON representation back to the original data format.
@@ -47,61 +47,77 @@
 <p>
     Publicly available DFDL schemas are available on the <a href="https://github.com/DFDLSchemas">DFDL Schemas github</a>.
 </p>
+<h2>External Variables</h2>
+<p>
+    DFDL external variables are supported using NiFi's dynamic properties.
+</p>
+<p>
+    To set an external variable, click the <code>"+"</code> sign in the top right of the processor's
+    properties tab to add a new dynamic property. The name of the property should be the same as the name of the
+    variable. Additionally, if the variable name alone is ambiguous, you can provide a namespace prefix and a
+    colon (e.g. <code>ns:variableName</code>) or a full namespace URI surrounded by curly braces (e.g.
+    <code>{http://example.com/namespace}variableName</code>).
+</p>
+<p>
+    The value of the dynamic property is used for the value of the variable, and can be a simple value or a NiFi
+    expression to be evaluated for each flow file. In either case, if the value is the empty string, the variable is
+    ignored for that flowfile and is not provided to Daffodil. This is useful in cases where a NiFi expression
+    determines a variable is not valid for the 'DFDL Schema File' being used, or to temporarily disable a variable
+    without completely removing it.
+</p>
+
 <h2>Plugins and Schemas</h2>
 <p>
-    <p>
     The <tt>Plugins and Schemas</tt> property is a comma separated list of paths to files and/or directories that the
     processor can use to find Daffodil plugins and schemas.
-    </p>
-    <dl>
-        <dt>Plugins</dt>
-        <dd>
-            <p>
-            Some DFDL schemas may require the use of plugins, such as layers, user defined functions, or custom
-            character encodings. To make these available to NiFi Daffodil processors, these plugins can be compiled to
-            jars, and paths to the jars or parent directory may be added to the <tt>Plugins and Schemas</tt> property. For
-            example, if all Daffodil plugins are in the <tt>/usr/share/nifi-daffodil/plugins/</tt> directory, you might
-            set the property to the following:
-            </p>
-
-            <pre>
-            Plugins and Schemas: /usr/share/nifi-daffodil/plugins/</pre>
-        </dd>
-        <dt>Schemas</dt>
-        <dd>
-            <p>
-            The <tt>DFDL Schema File</tt> property is used to define the path to a schema to be compiled, or a saved
-            parser to reload if <tt>Pre-compiled schema</tt> is true. However, in some cases it may be more convenient
-            to provide the schema as a path inside a jar, or as just a filename instead of a full path. The <tt>Plugins
-            and Schemas</tt> property can be used for this purpose.
-            </p>
-
-            <p>
-            If a schema (or saved parser) is defined in a jar, then add the jar to the <tt>Plugins and Schemas</tt>
-            property (either as a path to the directory containing the jar or a path to the jar itself), and set the
-            <tt>DFDL Schema File</tt> property to the <i>absolute path</i> to the schema <i>inside</i> the jar. For
-            example, if a jar at <tt>/usr/share/nifi-daffodil/schemas/dfdl-foo.jar</tt> contains a DFDL schema file
-            called <tt>com/example/foo.dfdl.xsd</tt>, you might configure the following:
-            </p>
-
-            <pre>
-            DFDL Schema File: /com/example/foo.dfdl.xsd
-            Plugins and Schemas: /usr/share/nifi-daffodil/schemas/</pre>
-
-            <p>
-            If a schema (or saved parser) is not in a jar, then add the file to the <tt>Plugins and Schemas</tt>
-            property (either as a path to the directory containing the file or a path to the file itself) and set the
-            <tt>DFDL Schema File</tt> property to just the file name. For example, if a saved parser is at
-            <tt>/usr/share/nifi-daffodil/saved-parsers/foo.bin</tt>, you might configure the following:
-            </p>
-
-            <pre>
-            DFDL Schema File: foo.bin
-            Plugins and Schemas: /usr/share/nifi-daffodil/saved-parsers/
-            Pre-compiled Schema: true</pre>
-        </dd>
-    </dl>
 </p>
+
+<h3>Plugins</h3>
+<p>
+    Some DFDL schemas may require the use of plugins, such as layers, user defined functions, or custom character
+    encodings. To make these available to NiFi Daffodil processors, these plugins can be compiled to jars, and paths to
+    individual jars or to a parent directory containing one or more jars may be added to the <tt>Plugins and
+    Schemas</tt> property. For example, if all Daffodil plugins are in the <tt>/usr/share/nifi-daffodil/plugins/</tt>
+    directory, you might set the property to the following:
+</p>
+<code><pre>
+Plugins and Schemas: /usr/share/nifi-daffodil/plugins/
+</pre></code>
+
+<h3>Schemas</h3>
+<p>
+    The <tt>DFDL Schema File</tt> property is used to define the path to a schema to be compiled, or a saved
+    parser to reload if <tt>Pre-compiled schema</tt> is true. However, in some cases it may be more convenient
+    to provide the schema as a path inside a jar, or as just a filename instead of a full path. The <tt>Plugins
+    and Schemas</tt> property can be used for this purpose.
+</p>
+<p>
+    If a schema (or saved parser) is defined in a jar, then add the jar to the <tt>Plugins and Schemas</tt>
+    property (either as a path to the directory containing the jar or a path to the jar itself), and set the
+    <tt>DFDL Schema File</tt> property to the <i>absolute path</i> to the schema <i>inside</i> the jar. For
+    example, if a jar at <tt>/usr/share/nifi-daffodil/schemas/dfdl-foo.jar</tt> contains a DFDL schema file
+    called <tt>com/example/foo.dfdl.xsd</tt>, you might configure the following:
+</p>
+<code><pre>
+DFDL Schema File: /com/example/foo.dfdl.xsd
+Plugins and Schemas: /usr/share/nifi-daffodil/schemas/
+</pre></code>
+<p>
+    In the above example, notice how the DFDL Schema File path begins with a '/', which denotes that the file is to be
+    found at that location inside a jar file.
+</p>
+<p>
+    If a schema (or saved parser) is not in a jar, then add the file to the <tt>Plugins and Schemas</tt>
+    property (either as a path to the directory containing the file or a path to the file itself) and set the
+    <tt>DFDL Schema File</tt> property to just the file name. For example, if a saved parser is at
+    <tt>/usr/share/nifi-daffodil/saved-parsers/foo.bin</tt>, you might configure the following:
+</p>
+<code><pre>
+DFDL Schema File: foo.bin
+Plugins and Schemas: /usr/share/nifi-daffodil/saved-parsers/
+Pre-compiled Schema: true
+</pre></code>
+
 <h2>Compiled DFDL Schema Cache</h2>
 <p>
     Before a FlowFile can be parsed or unparsed, Daffodil first compiles the DFDL schema to an internal data
@@ -111,16 +127,27 @@
     <dl>
         <dt>Cache Size</dt>
         <dd>
+            <p>
             Defines the maximum number of DFDL schemas that can be compiled and saved for rapid reuse from the
             cache. To avoid compilation, it is recommended that this value be larger than the expected number
             of possible DFDL schemas. Setting this value to 0 disables the cache, though this is not
-            recommended.
+            recommended. The default value is 50.
+            </p>
         </dd>
         <dt>Cache TTL after last access</dt>
         <dd>
-            Defines the cache time-to-live, or how long to keep an unused compiled DFDL schemas in the cache. To avoid
-            compilation, it is recommended that this should be larger than the amount of time it is expected
-            for a DFDL schema to be unused.
+            <p>
+            Cached compiled DFDL schemas that go unused for a specified amount of time are removed from the cache to
+            save memory. This time is defind by the <tt>Cache TTL after last access</tt> property, with the format of
+            <tt>&lt;duration&gt; &lt;time_unit&gt;</tt>, where <tt>&lt;duration&gt;</tt> is a non-negative integer and
+            <tt>&lt;time_unit&gt;</tt> is a supported unit of time, such as nanos, millis, secs, mins, hrs, days. If set
+            to zero (e.g. "0 seconds"), cached compiled DFDL schemas are never removed from the cache. The default value
+            is 30 minutes.
+            </p>
+            <p>
+            For example, if a schema is used occasionally (once a day perhaps), then set this to <tt>24 hours</tt> to
+            avoid recompiling it each time it is used.
+            </p>
         </dd>
     </dl>
 </p>

--- a/nifi-daffodil-processors/src/test/resources/TestDaffodilProcessor/bitlength.dfdl.xsd
+++ b/nifi-daffodil-processors/src/test/resources/TestDaffodilProcessor/bitlength.dfdl.xsd
@@ -24,7 +24,7 @@
   <xs:annotation>
     <xs:appinfo source="http://www.ogf.org/dfdl/">
       <dfdl:format ref="ex:GeneralFormat" representation="binary" lengthUnits="bits" alignmentUnits="bits"
-        lengthKind="implicit" separator="" />
+        lengthKind="implicit" separator="" byteOrder="{ $dfdl:byteOrder }" />
     </xs:appinfo> 
   </xs:annotation>
 

--- a/nifi-daffodil-processors/src/test/resources/TestDaffodilProcessor/noleftover_le.bin.xml
+++ b/nifi-daffodil-processors/src/test/resources/TestDaffodilProcessor/noleftover_le.bin.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><ex:root xmlns:ex="http://example.com"><length>16</length><number>53727</number></ex:root>


### PR DESCRIPTION
The name/value of NiFi dynamic properties are now treated as DFDL external variables. Property values are allowed to be NiFi expressions, which are evaluated and set as the variable values. If a property value evaluates to the empty string, it is ignored--this helps when a NiFi expression determines that a variable does not apply for a schema, since DFDL requires that all variables passed in externally must be valid for the schema. This does mean it is not possible to have a variable with the value of an empty string, but this should be rare and worked around.

This also refactored exceptions, so that functions throw correct exceptions instead of turning everything into an IOException, which worked but is not technically correct.

Also added a new "External Variables" section to additional details pages documening this capability, and cleaned up the additional details pages.