### PR TITLE
Disable cache TTL by default

### DIFF
--- a/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/AbstractDaffodilProcessor.java
+++ b/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/AbstractDaffodilProcessor.java
@@ -129,7 +129,7 @@ public abstract class AbstractDaffodilProcessor extends AbstractProcessor {
     public static final PropertyDescriptor CACHE_SIZE = new PropertyDescriptor.Builder()
             .name("cache-size")
             .displayName("Cache Size")
-            .description("Maximum number of compiled DFDL schemas to cache. Zero disables the cache.")
+            .description("Maximum number of compiled DFDL schemas to cache. Zero disables the cache. Restart the processor to manually empty the cache and recompile/reload schemas as needed.")
             .required(true)
             .defaultValue("50")
             .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
@@ -138,9 +138,9 @@ public abstract class AbstractDaffodilProcessor extends AbstractProcessor {
     public static final PropertyDescriptor CACHE_TTL_AFTER_LAST_ACCESS = new PropertyDescriptor.Builder()
             .name("cache-ttl-after-last-access")
             .displayName("Cache TTL After Last Access")
-            .description("The cache TTL (time-to-live) or how long to keep compiled DFDL schemas in the cache after last access.")
+            .description("Defines how long keep unused compiled DFDL schemas in the cache before removing them to free memory. Defaults to '0 seconds' which means to never remove cached schemas. Restart the processor to manually empty the cache and recompile/reload schemas as needed.")
             .required(true)
-            .defaultValue("30 mins")
+            .defaultValue("0 seconds")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .build();
 

--- a/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilParse/additionalDetails.html
+++ b/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilParse/additionalDetails.html
@@ -139,9 +139,8 @@ Pre-compiled Schema: true
             Cached compiled DFDL schemas that go unused for a specified amount of time are removed from the cache to
             save memory. This time is defind by the <tt>Cache TTL after last access</tt> property, with the format of
             <tt>&lt;duration&gt; &lt;time_unit&gt;</tt>, where <tt>&lt;duration&gt;</tt> is a non-negative integer and
-            <tt>&lt;time_unit&gt;</tt> is a supported unit of time, such as nanos, millis, secs, mins, hrs, days. If set
-            to zero (e.g. "0 seconds"), cached compiled DFDL schemas are never removed from the cache. The default value
-            is 30 minutes.
+            <tt>&lt;time_unit&gt;</tt> is a supported unit of time, such as nanos, millis, secs, mins, hrs, days. The
+            default is "0 seconds", which means compiled DFDL schemas are never removed from the cache.
             </p>
             <p>
             For example, if a schema is used occasionally (once a day perhaps), then set this to <tt>24 hours</tt> to
@@ -149,6 +148,9 @@ Pre-compiled Schema: true
             </p>
         </dd>
     </dl>
+</p>
+<p>
+Restart the processor to manually empty the cache and recompile/reload schemas as needed.
 </p>
 
 </body>

--- a/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilUnparse/additionalDetails.html
+++ b/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilUnparse/additionalDetails.html
@@ -140,9 +140,8 @@ Pre-compiled Schema: true
             Cached compiled DFDL schemas that go unused for a specified amount of time are removed from the cache to
             save memory. This time is defind by the <tt>Cache TTL after last access</tt> property, with the format of
             <tt>&lt;duration&gt; &lt;time_unit&gt;</tt>, where <tt>&lt;duration&gt;</tt> is a non-negative integer and
-            <tt>&lt;time_unit&gt;</tt> is a supported unit of time, such as nanos, millis, secs, mins, hrs, days. If set
-            to zero (e.g. "0 seconds"), cached compiled DFDL schemas are never removed from the cache. The default value
-            is 30 minutes.
+            <tt>&lt;time_unit&gt;</tt> is a supported unit of time, such as nanos, millis, secs, mins, hrs, days. The
+            default is "0 seconds", which means compiled DFDL schemas are never removed from the cache.
             </p>
             <p>
             For example, if a schema is used occasionally (once a day perhaps), then set this to <tt>24 hours</tt> to
@@ -150,6 +149,9 @@ Pre-compiled Schema: true
             </p>
         </dd>
     </dl>
+</p>
+<p>
+Restart the processor to manually empty the cache and recompile/reload schemas as needed.
 </p>
 
 </body>


### PR DESCRIPTION
The current cache TTL default is 30 minutes, which is relatively short and could easily lead to hiccups if there is a lull in data, a schema is removed from the cache and Daffodil needs to recompile it when data starts flowing again.

To avoid these hiccups, this changes the default to 0 seconds, which means to never remove schemas from the cache. In most cases, if a user uses a schema once they are probably going to use it again, so this avoids recompilations that could lead to unexpected latencies.